### PR TITLE
Avoid sending empty write_chunk packet (fixes #1)

### DIFF
--- a/src/mdfu/mdfu.c
+++ b/src/mdfu/mdfu.c
@@ -534,9 +534,13 @@ ssize_t mdfu_write_chunk(const image_reader_t *image_reader, int size){
         ERROR("%s", strerror(errno));
         return -1;
     }
-    mdfu_cmd_packet.data_length = (uint16_t) read_size;
-    if(mdfu_send_cmd(&mdfu_cmd_packet, &mdfu_status_packet) < 0){
-        return -1;
+    if(read_size == 0){
+        DEBUG("Reached end of image file");
+    } else {
+        mdfu_cmd_packet.data_length = (uint16_t) read_size;
+        if(mdfu_send_cmd(&mdfu_cmd_packet, &mdfu_status_packet) < 0){
+            return -1;
+        }
     }
     return read_size;
 }


### PR DESCRIPTION
If the image file read returns 0 bytes, then do not send a write_check command, as it will be rejected by the bootloader.
Also added a debug print statement when this condition occurs.

Fixes #1 